### PR TITLE
Fixed an error of to_depth method

### DIFF
--- a/ajpastor/dd_functions/ddFunction.py
+++ b/ajpastor/dd_functions/ddFunction.py
@@ -1139,10 +1139,10 @@ class DDRing (Ring_w_Sequence, IntegralDomain, SerializableObject):
         '''
         if(dest == 0):
             return self.original_ring()
-        elif(dest > 1 and self.operator_class is w_OreOperator):
-            operator_class = DDRing._Default_Operator
-        else:
+        elif(dest == 1 and self.operator_class is w_OreOperator):
             operator_class = w_OreOperator
+        else:
+            operator_class = DDRing._Default_Operator
 
         return DDRing(self.original_ring(), 
         depth = dest, 


### PR DESCRIPTION
The decision to use w_OreOperator was in such a way that this class was picked for something different than depth 1.